### PR TITLE
Mobile fixes

### DIFF
--- a/src/components/page/Hero.astro
+++ b/src/components/page/Hero.astro
@@ -101,7 +101,7 @@ const { style = "page" }: Props = Astro.props;
         }
 
         &.page {
-            min-height: 84px;
+            min-height: 8rem;
 
             img {
                 max-height: 3rem;

--- a/src/styles/global/global.scss
+++ b/src/styles/global/global.scss
@@ -36,7 +36,10 @@ b {
 }
 
 h1, h2 {
-  text-decoration: underline $color-red-400 0.1em;
+  // note: writing this as text-decoration shorthand does not work on safari 
+  text-decoration-line: underline;
+  text-decoration-color: $color-red-400;
+  text-decoration-thickness: 0.3rem;
 }
 
 


### PR DESCRIPTION
Note: the text-decoration thickness was set to 0.1rem but that wasn't applied. 
The default thickness was used, around 0.3 rem. So, I set it to that value.