### PR TITLE
Add day labels to schedule menu

### DIFF
--- a/src/components/page/menu.astro
+++ b/src/components/page/menu.astro
@@ -140,13 +140,16 @@ const { location }: Props = Astro.props;
         text-decoration: none;
 
         span {
-          padding: 0.15rem 0.3rem 0.05rem 0.3rem;
-          vertical-align: middle;
-          margin-right: 1rem;
-          background-color: variables.$color-yellow-300;
+          height: 1.75rem;
+          line-height: 1;
+          padding-inline: 0.3rem;
+          display: flex;
+          align-items: center;
+          margin-right: 0.75rem;
+          background-color: variables.$color-yellow-400;
           border-radius: 0.5rem;
           font-family: monospace;
-          font-size: smaller;
+          font-size: variables.$font-size-sm;
         }
       }
 

--- a/src/components/page/menu.astro
+++ b/src/components/page/menu.astro
@@ -145,7 +145,7 @@ const { location }: Props = Astro.props;
           padding-inline: 0.3rem;
           display: flex;
           align-items: center;
-          margin-right: 0.75rem;
+          margin-right: 0.5rem;
           background-color: variables.$color-yellow-400;
           border-radius: 0.5rem;
           font-family: monospace;

--- a/src/components/page/menu.astro
+++ b/src/components/page/menu.astro
@@ -21,12 +21,16 @@ const { location }: Props = Astro.props;
             href="/overview"
             >Overview of the week</a
           >
-          <a href="/schedule/tuesday" role="menuitem">Tuesday talks</a>
-          <a href="/schedule/wednesday" role="menuitem">Wednesday Talks</a>
-          <a href="/workshops" role="menuitem">Workshops</a>
+          <a href="/schedule/tuesday" role="menuitem"><span>tue</span>Conference day 1</a>
         </li>
-        <li class="child" role="menuitem">
-          <a href="/industry">Industry track</a>
+        <li>
+          <a href="/schedule/wednesday" role="menuitem"><span>wed</span>Conference day 2</a>
+        </li>
+        <li>
+          <a href="/workshops" role="menuitem"><span>thu</span>Workshops</a>
+        </li>
+        <li>
+          <a href="/overview/#hackathon" role="menuitem"><span>fri</span>Hackathon</a>
         </li>
       </ul>
     </li>
@@ -126,10 +130,24 @@ const { location }: Props = Astro.props;
         list-style: none;
         margin: 0;
         padding: 0;
+
+        button {
+          text-align: left;
+        }
       }
 
       a {
         text-decoration: none;
+
+        span {
+          padding: 0.15rem 0.3rem 0.05rem 0.3rem;
+          vertical-align: middle;
+          margin-right: 1rem;
+          background-color: variables.$color-yellow-300;
+          border-radius: 0.5rem;
+          font-family: monospace;
+          font-size: smaller;
+        }
       }
 
       span {


### PR DESCRIPTION
Add day labels to schedule menu. 

Also: 

- Clarify naming by changing to "conference day X"
- Fix alignment of button in menu
- Removes industry track from schedule menu

Todo:

- [x] improve styling with @grafische-republiek 

Before vs after:

![Screenshot 2025-03-22 3 17 49 PM](https://github.com/user-attachments/assets/50a618a5-c399-4958-bd44-7279a9d52093)
![Screenshot 2025-03-22 3 17 39 PM](https://github.com/user-attachments/assets/dbb0ab40-079b-4453-a27a-cec4e9668b73)
![Screenshot 2025-03-22 3 17 17 PM](https://github.com/user-attachments/assets/79698294-ca9b-46da-87e0-3ce4e8238559)
![Screenshot 2025-03-22 3 17 26 PM](https://github.com/user-attachments/assets/9ac9040c-6f77-4cfd-bab0-0dd95fc7c82b)